### PR TITLE
Adds direct support for stopping after MaxAttempts

### DIFF
--- a/exponential/policy.go
+++ b/exponential/policy.go
@@ -35,6 +35,9 @@ type Policy struct {
 	// MaxInterval is the maximum amount of time to wait between retries. Must be > 0.
 	// Defaults to 60s.
 	MaxInterval time.Duration
+	// MaxAttempts is the maximum number of attempts to make before giving up. If 0, then there is no limit.
+	// Defaults to 0. When this occurs, the error returned will contain ErrPermanent.
+	MaxAttempts int
 }
 
 func (p Policy) validate() error {


### PR DESCRIPTION
This allows a user to set MaxAttempts in a Policy. The default is 0 which means foreve, it succeeds or until ErrPermanent is set. Anything above 0 restricts it to that number of attempts. So 1 eliminates retries. 2 allows 1 failure and 1 retry. 

